### PR TITLE
Use https protocol instead of git to get around corporate proxies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	"keywords" : [ "upnp", "dlna", "ssdp", "soap", "nsd" ],
 	"main" : "index",
 	"dependencies" : {
-		"xml2js" : "git://github.com/fraunhoferfokus/node-xml2js.git",
+		"xml2js" : "git+https://github.com/fraunhoferfokus/node-xml2js.git",
 		"peer-ssdp": "0.0.3",
 		"ejs": "0.8.4",
 		"node-uuid": "1.4.0"


### PR DESCRIPTION
A quick fix for a potential niche use case but my corporate proxy (and many others) don't allow the git protocol or git through http so using github's https option is usually a safe bet for git based dependencies.
