### PR TITLE
Update peer-ssdp to version 0.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"main" : "index",
 	"dependencies" : {
 		"xml2js" : "git+https://github.com/fraunhoferfokus/node-xml2js.git",
-		"peer-ssdp": "0.0.4",
+		"peer-ssdp": "0.0.5",
 		"ejs": "0.8.4",
 		"node-uuid": "1.4.0"
 	},


### PR DESCRIPTION
I'm running into journalling issues due to the verbose logging in peer-ssdp which is fixed in 0.0.5. I figured bumping the version in peer-upnp is logical.

Cheers
