### PR TITLE
Fix setting xml namespace for responses

### DIFF
--- a/lib/peer-upnp.js
+++ b/lib/peer-upnp.js
@@ -723,7 +723,7 @@ var handlePostControl = function(req,rsp,peer){
 							inputs = {};
 						}
 						var options = {
-							serviceType: service.type,
+							serviceType: service.serviceType,
 							actionName: actionName
 						};
 						


### PR DESCRIPTION
For improved complicance with the spec the xmlns for responses needs to include the full namespace with schema, service, type and version.

With this fix xmlns changes from e.g. "AVTransport" to "urn:schemas-upnp-org:service:AVTransport:1".

The issue has been reported in private by email.
